### PR TITLE
Adds psycopg2 as an extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup(
     install_requires=[
         'requests'
     ],
+    extras_require = {
+        'sql':  ["psycopg2"]
+    }
     classifiers=[
         'Intended Audience :: Developers',
     ],


### PR DESCRIPTION
can install psycopg2 by using the command line syntax

```pip install -e .[sql]```