### PR TITLE
Moves import of psycopg2

### DIFF
--- a/gts/main.py
+++ b/gts/main.py
@@ -6,7 +6,6 @@ import os
 from collections import OrderedDict
 import datetime
 import getpass
-import psycopg2
 import requests
 
 
@@ -239,6 +238,15 @@ def store_db(db_config={}, repo='', json_response='', response_type=''):
    :param json_response: json - the json input
    :param response_type: str - 'views', 'clones', ''
    """
+   
+   try:
+      import psycopg2
+   except:
+      import sys
+      sys.stderr.write('The psycopg2 library is required to use database features.\n')
+      sys.stderr.flush()
+      sys.exit(1)
+
    # Connect to database 
    conn = psycopg2.connect(host=db_config['host'], port=db_config['port'], user=db_config['user'], password=db_config['password'], dbname=db_config['dbname']) 
    conn.autocommit = True


### PR DESCRIPTION
I moved the import of psycopg2 into the function that uses it. This makes it so that psycopg2 is not a requirement but instead an option. This is a better way to go if a user is not needing the database features.

I also added a graceful way of exiting the application in the event tht the psycopg2 library has not been installed but the database features are used.